### PR TITLE
Fix broken links to games in tag list

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -40,14 +40,14 @@
 					<% games.forEach( function(element){ %>
 					<div class="card">
 
-						 <a href=<%= "game/"+element.data.permalink %>>
+						 <a href="<%= "/game/"+element.data.permalink %>">
 						 	<% if (element.data.screenshots[0]) { %>
-						 	<img class="card-img-top img-fluid" src=/<%= "database/entries/" + element.data.permalink + "/" + element.data.screenshots[0] %> alt="Card image cap"></a>
+						 	<img class="card-img-top img-fluid" src="<%= "/database/entries/" + element.data.permalink + "/" + element.data.screenshots[0] %>" alt="Card image cap"></a>
 						 	<% } else { %>
-						 	<img class="card-img-top img-fluid" src='database/placeholder.png' alt="Card image cap"></a>
+						 	<img class="card-img-top img-fluid" src='/database/placeholder.png' alt="Card image cap"></a>
 						 	<%  } %>
 						<div class="card-body">
-							<a href=<%= "game/"+element.data.permalink %>><h4 class="card-title"> <%= element.data.title %> </a>
+							<a href="<%= "/game/"+element.data.permalink %>"><h4 class="card-title"> <%= element.data.title %> </a>
 							<% if (element.data.typetag == "game") { %>
 							<span style="float:right; font-size: 0.7em" class="fa fa-gamepad"></span></h3>
 							<% } else if (element.data.typetag == "demo") { %>


### PR DESCRIPTION
Make relative links to games absolute, so they also work when view is filtered by tag.

(To reproduce, [select a tag](https://gbhh.avivace.com/games/open-source) and then try to [select a game](https://gbhh.avivace.com/games/game/ucity).)